### PR TITLE
Add font family Barlow and Maven Pro

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Barlow:wght@400;500&family=Maven+Pro:wght@400;500&display=swap');
+
 * {
   margin: 0;
   padding: 0;
@@ -36,6 +38,7 @@ button {
   color: #fff;
   font-size: 14px;
   transition: all 0.3s ease;
+  font-family: "Barlow", "Maven Pro", sans-serif;
 }
 
 button:hover {


### PR DESCRIPTION
This fixes #32 

I've added a font family which are Barlow and Maven Pro for the buttons in the App.css file.

![ChangedFont](https://user-images.githubusercontent.com/54873998/137567246-b411f3b9-d7a7-4a24-916a-4b53feadd4af.JPG)

Please let me know if I need to improve.
Thank you for your consideration! 