### PR TITLE
Timer now resets to 00:00 (fix: #44)

### DIFF
--- a/src/playSound.js
+++ b/src/playSound.js
@@ -31,6 +31,10 @@ class SoundComponent extends Component {
 
   reset() {
     this.setState({ position: 0 })
+    const timerMin = document.getElementById('timer-min')
+    const timerSec = document.getElementById('timer-sec')
+    timerMin.innerHTML = '00'
+    timerSec.innerHTML = '00'
   }
 
   render() {


### PR DESCRIPTION
Fix for issue #44 

Timer now resets to 00:00 on being reset, by setting the inner html of the timer stats (mins and secs) to '00's.

There is a better way to do it with states and hooks, but since the entire project is built on class components, I simply extended that to fix it.